### PR TITLE
Add BigQuery automatic table setup

### DIFF
--- a/db/bq/tables.go
+++ b/db/bq/tables.go
@@ -1,0 +1,54 @@
+package bq
+
+import (
+	"cloud.google.com/go/bigquery"
+	log "github.com/Sirupsen/logrus"
+	"golang.org/x/net/context"
+)
+
+// Determines whether two BigQuery schemas are the same. Currently does not
+// support nested schemas and only checks the name and type of the fields.
+func IsSameSchema(s1, s2 bigquery.Schema) bool {
+	for _, f1 := range s1 {
+		found := false
+		for _, f2 := range s2 {
+			if f1.Name == f2.Name && f1.Type == f2.Type {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Ensure that the given table is up-to-date.
+// - If the table does not exist, it will be created
+// - If the table exists but the schema is outdated, it will be updated
+// - Otherwise nothing happens
+// The function panics if any of its API calls fail.
+func EnsureTable(table *bigquery.Table, schema bigquery.Schema, options ...bigquery.CreateTableOption) {
+	ctx := context.Background()
+
+	logger := log.WithField("table", table.TableID)
+	logger.Debug("Checking table metadata")
+
+	meta, err := table.Metadata(ctx)
+
+	if err != nil {
+		logger.Info("Error fetching table. Assuming it does not exist. Creating it")
+		options = append(options, schema)
+		if err = table.Create(ctx, options...); err != nil {
+			logger.Panic("Could not create BigQuery table", err)
+		}
+	} else if !IsSameSchema(schema, meta.Schema) {
+		logger.Info("Schema is out of date. Updating it")
+		update := bigquery.TableMetadataToUpdate{Schema: schema}
+		if meta, err = table.Update(ctx, update); err != nil {
+			logger.Panic("Could not update BigQuery table", err)
+		}
+	}
+}

--- a/db/bq/tables_test.go
+++ b/db/bq/tables_test.go
@@ -1,0 +1,188 @@
+package bq
+
+import (
+	"fmt"
+	"testing"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/jarcoal/httpmock.v1"
+)
+
+func TestIsSameSchema(t *testing.T) {
+	cases := []struct {
+		s1   bigquery.Schema
+		s2   bigquery.Schema
+		want bool
+	}{
+		{
+			bigquery.Schema{},
+			bigquery.Schema{},
+			true,
+		},
+		{
+			bigquery.Schema{&bigquery.FieldSchema{Name: "a"}},
+			bigquery.Schema{&bigquery.FieldSchema{Name: "a"}},
+			true,
+		},
+		{
+			bigquery.Schema{&bigquery.FieldSchema{Name: "a"}, &bigquery.FieldSchema{Name: "b"}},
+			bigquery.Schema{&bigquery.FieldSchema{Name: "b"}, &bigquery.FieldSchema{Name: "a"}},
+			true,
+		},
+		{
+			bigquery.Schema{&bigquery.FieldSchema{Name: "a"}},
+			bigquery.Schema{&bigquery.FieldSchema{Name: "b"}},
+			false,
+		},
+	}
+
+	for i, c := range cases {
+		got := IsSameSchema(c.s1, c.s2)
+		if got != c.want {
+			t.Errorf("Got %b, wanted %b, case %d", got, c.want, i)
+		}
+	}
+}
+
+func TestEnsureTableUpdate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	// Responder for the metadata request for mytable
+	tableUrl := "https://www.googleapis.com/bigquery/v2/projects/some-project/datasets/some_dataset/tables/mytable"
+	httpmock.RegisterResponder("GET", tableUrl,
+		httpmock.NewStringResponder(200, `
+			{
+			  "kind": "bigquery#table",
+			  "etag": "\"hej\"",
+			  "id": "some-project:some_dataset.mytable",
+			  "tableReference": {
+			   "projectId": "some-project",
+			   "datasetId": "some_dataset",
+			   "tableId": "mytable"
+			  },
+			  "numBytes": "0",
+			  "numLongTermBytes": "0",
+			  "numRows": "0",
+			  "creationTime": "1480687735761",
+			  "expirationTime": "1481292535761",
+			  "lastModifiedTime": "1480687735761",
+			  "type": "TABLE"
+			}`))
+
+	// Responder for the patch operation when table exists but needs updating
+	httpmock.RegisterResponder("PATCH", tableUrl,
+		httpmock.NewStringResponder(200, "{}"))
+
+	myStruct := struct {
+		ID string `bigquery:"id"`
+	}{"abc"}
+
+	schema, err := bigquery.InferSchema(myStruct)
+	require.NoError(t, err)
+
+	wrapper := Setup()
+	require.NotNil(t, wrapper)
+	table := wrapper.Table("mytable")
+
+	EnsureTable(table, schema)
+
+	// Ensure that the table was fetched, it determined the schema is wrong, and it updated.
+	callInfo := httpmock.GetCallCountInfo()
+	getRequest := fmt.Sprintf("GET %s", tableUrl)
+	patchRequest := fmt.Sprintf("PATCH %s", tableUrl)
+	assert.Equal(t, 1, callInfo[getRequest])
+	assert.Equal(t, 1, callInfo[patchRequest])
+}
+
+func TestEnsureTableCreate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	// Responder for the metadata request for mytable
+	tableUrl := "https://www.googleapis.com/bigquery/v2/projects/some-project/datasets/some_dataset/tables/mytable"
+	httpmock.RegisterResponder("GET", tableUrl,
+		httpmock.NewStringResponder(404, `
+{
+ "error": {
+  "errors": [
+   {
+    "domain": "global",
+    "reason": "notFound",
+    "message": "Not found: Table some-project:some_dataset.mytable"
+   }
+  ],
+  "code": 404,
+  "message": "Not found: Table some-project:some_dataset.mytable"
+ }
+}
+			`))
+
+	tablesUrl := "https://www.googleapis.com/bigquery/v2/projects/some-project/datasets/some_dataset/tables"
+	httpmock.RegisterResponder("POST", tablesUrl,
+		httpmock.NewStringResponder(200, "{}"))
+
+	myStruct := struct {
+		ID string `bigquery:"id"`
+	}{"abc"}
+
+	schema, err := bigquery.InferSchema(myStruct)
+	require.NoError(t, err)
+
+	wrapper := Setup()
+	require.NotNil(t, wrapper)
+	table := wrapper.Table("mytable")
+
+	EnsureTable(table, schema)
+	assert.NoError(t, err)
+
+	// Ensure that the table was fetched, it determined there was no table, and it created the table.
+	callInfo := httpmock.GetCallCountInfo()
+	getRequest := fmt.Sprintf("GET %s", tableUrl)
+	postRequest := fmt.Sprintf("POST %s", tablesUrl)
+	assert.Equal(t, 1, callInfo[getRequest])
+	assert.Equal(t, 1, callInfo[postRequest])
+}
+
+func TestEnsureTablePanic(t *testing.T) {
+	setup()
+	defer teardown()
+
+	// Responder for the metadata request for mytable
+	tableUrl := "https://www.googleapis.com/bigquery/v2/projects/some-project/datasets/some_dataset/tables/mytable"
+	httpmock.RegisterResponder("GET", tableUrl,
+		httpmock.NewStringResponder(404, `
+{
+ "error": {
+  "errors": [
+   {
+    "domain": "global",
+    "reason": "notFound",
+    "message": "Not found: Table some-project:some_dataset.mytable"
+   }
+  ],
+  "code": 404,
+  "message": "Not found: Table some-project:some_dataset.mytable"
+ }
+}
+			`))
+
+	tablesUrl := "https://www.googleapis.com/bigquery/v2/projects/some-project/datasets/some_dataset/tables"
+	httpmock.RegisterResponder("POST", tablesUrl,
+		httpmock.NewStringResponder(400, "{}"))
+
+	myStruct := struct {
+		ID string `bigquery:"id"`
+	}{"abc"}
+
+	schema, err := bigquery.InferSchema(myStruct)
+	require.NoError(t, err)
+
+	wrapper := Setup()
+	require.NotNil(t, wrapper)
+	table := wrapper.Table("mytable")
+
+	assert.Panics(t, func() { EnsureTable(table, schema) })
+}

--- a/test.sh
+++ b/test.sh
@@ -27,8 +27,9 @@ race() {
 
 cover() {
     echo "Running coverage"
-    rm coverage.txt
-    rm coverage.html
+    rm -f coverage.txt
+    rm -f coverage.html
+    touch coverage.tmp
     echo 'mode: atomic' > coverage.txt
     go list ./... | grep -v -e cmd | xargs -n1 -I{} sh -c 'go test -covermode=count -coverprofile=coverage.tmp {} && tail -n +2 coverage.tmp >> coverage.txt'
     rm coverage.tmp


### PR DESCRIPTION
This commit adds a new EnsureTable function to the BigQuery service that
creates or updates a BigQuery table, if necessary.

Other improvements:
- Add UseTablePrefix function to BigQuery wrapper instead of relying on
  environment variables.

Fixes:
- Calling Close twice no longer panics.
- Coverage test script reliability.