### PR TITLE
Add time utilities, adjust amqp, fix logrus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ _testmain.go
 cover.out
 coverage.*
 cmd/
+
+vendor/

--- a/db/bq/bq.go
+++ b/db/bq/bq.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/getconversio/go-utils/util"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"

--- a/db/bq/bq_test.go
+++ b/db/bq/bq_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/bigquery"
-	logtest "github.com/Sirupsen/logrus/hooks/test"
+	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/getconversio/go-utils/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/db/bq/tables.go
+++ b/db/bq/tables.go
@@ -2,7 +2,7 @@ package bq
 
 import (
 	"cloud.google.com/go/bigquery"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 )
 

--- a/services/amqp/amqp_test.go
+++ b/services/amqp/amqp_test.go
@@ -83,7 +83,7 @@ func teardown() {
 	close(intChannel)
 }
 
-func testHandle(f func(interface{}, amqp.Table) error) string {
+func testHandle(f func(interface{}, amqp.Table) error) (string, *amqp.Channel) {
 	return HandleFunc(
 		"test.mctest",  // Queue name
 		"test",         // Exchange name
@@ -154,7 +154,7 @@ func TestHandleFunc(t *testing.T) {
 	for _, c := range cases {
 		resetAcksNack()
 		resetQueues(t)
-		ctag := testHandle(c.fun)
+		ctag, _ := testHandle(c.fun)
 
 		// Force an error
 		err := ch.Publish(
@@ -295,7 +295,7 @@ func TestCloseOnCancel(t *testing.T) {
 		err = os.Setenv("RABBITMQ_EXIT_ON_CLOSE", "yes")
 		require.NoError(t, err)
 
-		ctag := testHandle(func(msg interface{}, headers amqp.Table) error { return nil })
+		ctag, _ := testHandle(func(msg interface{}, headers amqp.Table) error { return nil })
 		ch.Cancel(ctag, false) // This should exit the process
 
 		// Allow up to five seconds time for the handler to cancel and close

--- a/services/log/log.go
+++ b/services/log/log.go
@@ -3,9 +3,9 @@ package log
 import (
 	"os"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/getconversio/go-utils/util"
-	"github.com/puddingfactory/logentrus"
+	"github.com/getconversio/logentrus"
+	log "github.com/sirupsen/logrus"
 )
 
 func Setup() {

--- a/services/log/log_test.go
+++ b/services/log/log_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/test.sh
+++ b/test.sh
@@ -5,7 +5,7 @@ set -e
 ci() {
     echo "" > coverage.txt
 
-    for d in $(go list ./... | grep -v -e cmd); do
+    for d in $(go list ./... | grep -v -e cmd -e vendor); do
         go test -coverprofile=profile.out $d
         if [ -f profile.out ]; then
             cat profile.out >> coverage.txt
@@ -16,13 +16,13 @@ ci() {
 
 test() {
     echo "Running tests"
-    go test -cover $(go list ./... | grep -v -e cmd)
+    go test -cover $(go list ./... | grep -v -e cmd -e vendor)
     exit $?
 }
 
 race() {
     echo "Running tests with race check"
-    go test -race $(go list ./... | grep -v -e cmd)
+    go test -race $(go list ./... | grep -v -e cmd -e vendor)
 }
 
 cover() {
@@ -31,7 +31,7 @@ cover() {
     rm -f coverage.html
     touch coverage.tmp
     echo 'mode: atomic' > coverage.txt
-    go list ./... | grep -v -e cmd | xargs -n1 -I{} sh -c 'go test -covermode=count -coverprofile=coverage.tmp {} && tail -n +2 coverage.tmp >> coverage.txt'
+    go list ./... | grep -v -e cmd -e vendor | xargs -n1 -I{} sh -c 'go test -covermode=count -coverprofile=coverage.tmp {} && tail -n +2 coverage.tmp >> coverage.txt'
     rm coverage.tmp
     go tool cover -html coverage.txt -o coverage.html
 }

--- a/util/time.go
+++ b/util/time.go
@@ -1,0 +1,59 @@
+package util
+
+import "time"
+
+// Epoch is the unix epoch time: Jan 1, 1970
+var Epoch = time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+// TimeStartOf truncates the given timestamp to the given granularity. This is
+// is similar to Time.Truncate, but is also works for year, month and day.
+func TimeStartOf(t time.Time, granularity string) time.Time {
+	switch granularity {
+	case "year":
+		return time.Date(t.Year(), time.January, 1, 0, 0, 0, 0, t.Location())
+	case "month":
+		return time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, t.Location())
+	case "week":
+		// A week starts on a Monday golang!
+		dayDiff := -(int(t.Weekday()) - 1) // Monday - 1 = 0
+		if t.Weekday() == 0 {
+			dayDiff = -6
+		}
+		t = t.AddDate(0, 0, dayDiff)
+		return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+	case "day":
+		return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+	case "hour":
+		return t.Truncate(time.Hour)
+	case "minute":
+		return t.Truncate(time.Minute)
+	case "second":
+		return t.Truncate(time.Second)
+	}
+	return t
+}
+
+// TimeEndOf truncates a time to the end of a granularity, similar to TimeStartOf
+func TimeEndOf(t time.Time, granularity string) time.Time {
+	switch granularity {
+	case "year":
+		return TimeStartOf(t.AddDate(1, 0, 0), "year").Add(-1 * time.Microsecond)
+	case "month":
+		// Because month are normalized, adding a month to March 31 produces
+		// May 1. So to avoid this, we first go back to the beginning of the
+		// month before adding the new month.
+		startOfMonth := TimeStartOf(t, "month")
+		return TimeStartOf(startOfMonth.AddDate(0, 1, 0), "month").Add(-1 * time.Microsecond)
+	case "week":
+		return TimeStartOf(t.AddDate(0, 0, 7), "week").Add(-1 * time.Microsecond)
+	case "day":
+		return TimeStartOf(t.AddDate(0, 0, 1), "day").Add(-1 * time.Microsecond)
+	case "hour":
+		return TimeStartOf(t.Add(time.Hour), "hour").Add(-1 * time.Microsecond)
+	case "minute":
+		return TimeStartOf(t.Add(time.Minute), "minute").Add(-1 * time.Microsecond)
+	case "second":
+		return TimeStartOf(t.Add(time.Second), "second").Add(-1 * time.Microsecond)
+	}
+	return t
+}

--- a/util/time_test.go
+++ b/util/time_test.go
@@ -1,0 +1,80 @@
+package util
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeStartOf(t *testing.T) {
+	// February 3, 2016, 04:05:06
+	tt := time.Date(2016, time.February, 3, 4, 5, 6, 0, time.UTC)
+
+	assert.Equal(t, "2016-01-01T00:00:00Z", TimeStartOf(tt, "year").Format(time.RFC3339))
+	assert.Equal(t, "2016-02-01T00:00:00Z", TimeStartOf(tt, "month").Format(time.RFC3339))
+	assert.Equal(t, "2016-02-03T00:00:00Z", TimeStartOf(tt, "day").Format(time.RFC3339))
+	assert.Equal(t, "2016-02-03T04:00:00Z", TimeStartOf(tt, "hour").Format(time.RFC3339))
+	assert.Equal(t, "2016-02-03T04:05:00Z", TimeStartOf(tt, "minute").Format(time.RFC3339))
+	assert.Equal(t, "2016-02-03T04:05:06Z", TimeStartOf(tt, "second").Format(time.RFC3339))
+
+	// Everything else just returns the time itself.
+	assert.Equal(t, "2016-02-03T04:05:06Z", TimeStartOf(tt, "total").Format(time.RFC3339))
+
+	// Test all days of the week for week start.
+	dates := []time.Time{
+		time.Date(2016, time.February, 8, 4, 5, 6, 0, time.UTC),
+		time.Date(2016, time.February, 9, 4, 5, 6, 0, time.UTC),
+		time.Date(2016, time.February, 10, 4, 5, 6, 0, time.UTC),
+		time.Date(2016, time.February, 11, 4, 5, 6, 0, time.UTC),
+		time.Date(2016, time.February, 12, 4, 5, 6, 0, time.UTC),
+		time.Date(2016, time.February, 13, 4, 5, 6, 0, time.UTC),
+		time.Date(2016, time.February, 14, 4, 5, 6, 0, time.UTC),
+	}
+	for _, date := range dates {
+		assert.Equal(t, "2016-02-08T00:00:00Z", TimeStartOf(date, "week").Format(time.RFC3339))
+	}
+}
+
+func TestTimeEndof(t *testing.T) {
+	// February 3, 2016, 04:05:06
+	tt := time.Date(2016, time.February, 3, 4, 5, 6, 0, time.UTC)
+
+	assert.Equal(t, "2016-12-31T23:59:59Z", TimeEndOf(tt, "year").Format(time.RFC3339))
+	assert.Equal(t, "2016-02-29T23:59:59Z", TimeEndOf(tt, "month").Format(time.RFC3339))
+	assert.Equal(t, "2016-02-03T23:59:59Z", TimeEndOf(tt, "day").Format(time.RFC3339))
+	assert.Equal(t, "2016-02-03T04:59:59Z", TimeEndOf(tt, "hour").Format(time.RFC3339))
+	assert.Equal(t, "2016-02-03T04:05:59Z", TimeEndOf(tt, "minute").Format(time.RFC3339))
+	assert.Equal(t, "2016-02-03T04:05:06Z", TimeEndOf(tt, "second").Format(time.RFC3339))
+
+	// Everything else just returns the time itself.
+	assert.Equal(t, "2016-02-03T04:05:06Z", TimeEndOf(tt, "total").Format(time.RFC3339))
+
+	// Edge case for month around end of month
+	tt = time.Date(2016, time.March, 31, 4, 5, 6, 0, time.UTC)
+	assert.Equal(t, "2016-03-31T23:59:59Z", TimeEndOf(tt, "month").Format(time.RFC3339))
+	tt = time.Date(2016, time.January, 31, 4, 5, 6, 0, time.UTC)
+	assert.Equal(t, "2016-01-31T23:59:59Z", TimeEndOf(tt, "month").Format(time.RFC3339))
+
+	// Edge case around end of leap year (2016 was a leap year)
+	tt = time.Date(2016, time.December, 31, 4, 5, 6, 0, time.UTC)
+	assert.Equal(t, "2016-12-31T23:59:59Z", TimeEndOf(tt, "year").Format(time.RFC3339))
+
+	// Edge case around end of year before a leap year.
+	tt = time.Date(2015, time.December, 31, 4, 5, 6, 0, time.UTC)
+	assert.Equal(t, "2015-12-31T23:59:59Z", TimeEndOf(tt, "year").Format(time.RFC3339))
+
+	// Test all days of the week for week end.
+	dates := []time.Time{
+		time.Date(2016, time.February, 8, 4, 5, 6, 0, time.UTC),
+		time.Date(2016, time.February, 9, 4, 5, 6, 0, time.UTC),
+		time.Date(2016, time.February, 10, 4, 5, 6, 0, time.UTC),
+		time.Date(2016, time.February, 11, 4, 5, 6, 0, time.UTC),
+		time.Date(2016, time.February, 12, 4, 5, 6, 0, time.UTC),
+		time.Date(2016, time.February, 13, 4, 5, 6, 0, time.UTC),
+		time.Date(2016, time.February, 14, 4, 5, 6, 0, time.UTC),
+	}
+	for _, date := range dates {
+		assert.Equal(t, "2016-02-14T23:59:59Z", TimeEndOf(date, "week").Format(time.RFC3339))
+	}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"syscall"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 func Hash32(s string) string {


### PR DESCRIPTION
This commit includes three small changes:
1. A new time utility with two functions for finding the start of end of
a period
2. An adjustment to the amqp.HandleFunc function such that it returns
the channel the function was opened on.
3. A fix to logrus naming such that everything is lowercase.

For the logentries hook for logrus, getconversio is used temporarily for
now.

If https://github.com/puddingfactory/logentrus/pull/5 gets merged, we can use that version again.